### PR TITLE
Enables Enumerable functionality for ONFT721

### DIFF
--- a/contracts/oapp/onft721/ONFT721EnumerableUpgradeable.sol
+++ b/contracts/oapp/onft721/ONFT721EnumerableUpgradeable.sol
@@ -10,7 +10,7 @@ import { ONFT721CoreUpgradeable } from "./ONFT721CoreUpgradeable.sol";
  * @title ONFT721Enumerable Contract
  * @dev ONFT721 is an ERC-721 token that extends the functionality of the ONFT721Core contract.
  */
-abstract contract ONFT721EnumerableUpgradeable is ONFT721CoreUpgradeable, ERC721EnumerableUpgradeable {
+abstract contract ONFT721EnumerableUpgradeable is ONFT721CoreUpgradeable, ERC721Upgradeable, ERC721EnumerableUpgradeable {
     struct ONFT721EnumerableStorage {
         string baseTokenURI;
     }
@@ -39,8 +39,9 @@ abstract contract ONFT721EnumerableUpgradeable is ONFT721CoreUpgradeable, ERC721
         address _lzEndpoint,
         address _delegate
     ) internal onlyInitializing {
-        __ERC721_init(_name, _symbol);
         __ONFT721Core_init(_lzEndpoint, _delegate);
+        __ERC721_init(_name, _symbol);
+        __ERC721Enumerable_init();
     }
 
     /**
@@ -77,5 +78,29 @@ abstract contract ONFT721EnumerableUpgradeable is ONFT721CoreUpgradeable, ERC721
 
     function _credit(address _to, uint256 _tokenId, uint32 /*_srcEid*/) internal virtual override {
         _mint(_to, _tokenId);
+    }
+
+    function _update(address to, uint256 tokenId, address auth)
+        internal
+        override(ERC721Upgradeable, ERC721EnumerableUpgradeable)
+        returns (address)
+    {
+        return super._update(to, tokenId, auth);
+    }
+
+    function _increaseBalance(address account, uint128 value)
+        internal
+        override(ERC721Upgradeable, ERC721EnumerableUpgradeable)
+    {
+        super._increaseBalance(account, value);
+    }
+
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        override(ERC721Upgradeable, ERC721EnumerableUpgradeable)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
     }
 }

--- a/contracts/test/MockNFT.sol
+++ b/contracts/test/MockNFT.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.22;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import { ONFT721Upgradeable } from "../oapp/onft721/ONFT721Upgradeable.sol";
+import { ONFT721EnumerableUpgradeable } from "../oapp/onft721/ONFT721EnumerableUpgradeable.sol";
 
-contract MyONFT721 is Initializable, ONFT721Upgradeable {
+contract MyONFT721 is Initializable, ONFT721EnumerableUpgradeable {
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -16,7 +16,7 @@ contract MyONFT721 is Initializable, ONFT721Upgradeable {
         address _lzEndpoint,
         address _delegate
     ) public initializer {
-        __ONFT721_init(_name, _symbol, _lzEndpoint, _delegate);
+        __ONFT721Enumerable_init(_name, _symbol, _lzEndpoint, _delegate);
     }
 
     function mint(address _to, uint256 _amount) public {

--- a/contracts/test/MockNFTv2.sol
+++ b/contracts/test/MockNFTv2.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.22;
 
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
-import { ONFT721Upgradeable } from "../oapp/onft721/ONFT721Upgradeable.sol";
+import { ONFT721EnumerableUpgradeable } from "../oapp/onft721/ONFT721EnumerableUpgradeable.sol";
 
-contract MyONFT721v2 is Initializable, ONFT721Upgradeable {
+contract MyONFT721v2 is Initializable, ONFT721EnumerableUpgradeable {
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
         _disableInitializers();
@@ -16,7 +16,7 @@ contract MyONFT721v2 is Initializable, ONFT721Upgradeable {
         address _lzEndpoint,
         address _delegate
     ) public initializer {
-        __ONFT721_init(_name, _symbol, _lzEndpoint, _delegate);
+        __ONFT721Enumerable_init(_name, _symbol, _lzEndpoint, _delegate);
     }
 
     function mint(address _to, uint256 _amount) public {

--- a/test/MockNFT.ts
+++ b/test/MockNFT.ts
@@ -100,6 +100,81 @@ describe("MockNFT (MyONFT721) Tests", function () {
     });
   });
 
+  describe("Enumerable features", function () {
+    it("should track token by index", async function () {
+      const userAddress = await user1.getAddress();
+      
+      // Mint multiple tokens
+      await myONFT721.mint(userAddress, 1);
+      await myONFT721.mint(userAddress, 2);
+      await myONFT721.mint(userAddress, 3);
+      
+      // Check token by index
+      expect(await myONFT721.tokenByIndex(0)).to.equal(1);
+      expect(await myONFT721.tokenByIndex(1)).to.equal(2);
+      expect(await myONFT721.tokenByIndex(2)).to.equal(3);
+      
+      // Check total supply
+      expect(await myONFT721.totalSupply()).to.equal(3);
+    });
+    
+    it("should track tokens of owner by index", async function () {
+      const user1Address = await user1.getAddress();
+      const user2Address = await user2.getAddress();
+      
+      // Mint tokens to different users
+      await myONFT721.mint(user1Address, 1);
+      await myONFT721.mint(user2Address, 2);
+      await myONFT721.mint(user1Address, 3);
+      
+      // Check tokens of owner by index
+      expect(await myONFT721.tokenOfOwnerByIndex(user1Address, 0)).to.equal(1);
+      expect(await myONFT721.tokenOfOwnerByIndex(user1Address, 1)).to.equal(3);
+      expect(await myONFT721.tokenOfOwnerByIndex(user2Address, 0)).to.equal(2);
+      
+      // Check balances
+      expect(await myONFT721.balanceOf(user1Address)).to.equal(2);
+      expect(await myONFT721.balanceOf(user2Address)).to.equal(1);
+    });
+    
+    it("should handle base URI correctly", async function () {
+      const baseURI = "https://api.example.com/tokens/";
+      const tokenId = 1;
+      const userAddress = await user1.getAddress();
+      
+      // Mint a token
+      await myONFT721.mint(userAddress, tokenId);
+      
+      // Set base URI
+      await myONFT721.setBaseURI(baseURI);
+      
+      // Check token URI
+      expect(await myONFT721.tokenURI(tokenId)).to.equal(`${baseURI}${tokenId}`);
+    });
+    
+    it("should maintain enumerable state after transfer", async function () {
+      const user1Address = await user1.getAddress();
+      const user2Address = await user2.getAddress();
+      const tokenId = 1;
+      
+      // Mint token to user1
+      await myONFT721.mint(user1Address, tokenId);
+      
+      // Transfer token from user1 to user2
+      await myONFT721.connect(user1).transferFrom(user1Address, user2Address, tokenId);
+      
+      // Check token ownership
+      expect(await myONFT721.ownerOf(tokenId)).to.equal(user2Address);
+      
+      // Check enumerable state
+      expect(await myONFT721.tokenOfOwnerByIndex(user2Address, 0)).to.equal(tokenId);
+      expect(await myONFT721.tokenByIndex(0)).to.equal(tokenId);
+      expect(await myONFT721.totalSupply()).to.equal(1);
+      expect(await myONFT721.balanceOf(user1Address)).to.equal(0);
+      expect(await myONFT721.balanceOf(user2Address)).to.equal(1);
+    });
+  });
+
   describe("Upgradeable pattern", function () {
     it("should be upgradeable to a new implementation", async function () {
       // Deploy a new implementation of MyONFT721


### PR DESCRIPTION
Implements the Enumerable extension for the ONFT721 contract.

- Adds ERC721EnumerableUpgradeable to the inheritance of ONFT721EnumerableUpgradeable.
- Includes necessary overrides for ERC721EnumerableUpgradeable functions to maintain enumerable state.
- Updates tests to verify the enumerable functionality, including token tracking by index and owner.